### PR TITLE
OPS-2555 Remove AWS account check for switching kubectl context

### DIFF
--- a/templates/kubectl-context.sh.j2
+++ b/templates/kubectl-context.sh.j2
@@ -14,30 +14,6 @@ if [ "${#}" -gt "0" ] && [ "${1}" = "--yes" ]; then
 	RUN=1
 fi
 
-{# Start of AWS Account check #}
-{% if kops_default_aws_account_limit | length > 0 %}
-if [ "${RUN}" -eq "1" ]; then
-	if ! command -v aws >/dev/null 2>&1; then
-		>&2 echo "Error, aws binary not available but required to check for correct AWS account."
-		exit 1
-	fi
-	if ! AWS_ACCOUNT="$( aws sts get-caller-identity --output text --query 'Account' )"; then
-		>&2 echo "Error, 'aws sts get-caller-identity' failed."
-		exit 1
-	fi
-	FOUND=0
-{% for acc in kops_default_aws_account_limit %}
-	if [ "${AWS_ACCOUNT}" = "{{ acc }}" ]; then
-		FOUND=1
-	fi
-{% endfor %}
-	if [ "${FOUND}" -ne "1" ]; then
-		>&2 echo "Error, ${AWS_ACCOUNT} is not allowed."
-		exit 1
-	fi
-fi
-{% endif %}
-{# End of AWS Account check #}
 
 
 echo


### PR DESCRIPTION
# Remove AWS account check for switching kubectl context

Currently the kubectl switch context script checks for a valid AWS login, this however is not even required to switch the context and is currently a pain.

This PR just gets rid of the account check.

## Upcoming git tag: `v1.3.1`
