### PR TITLE
OPS-2538 Fix generation of kubeAPIServer block in cluster.yml

### DIFF
--- a/templates/cluster.yml.j2
+++ b/templates/cluster.yml.j2
@@ -15,8 +15,9 @@ spec:
   docker:
     insecureRegistry: 100.64.0.0/10
     logDriver: ""
-{% if 'kube_api_server' in cluster %}
-  kubeAPIServer: "{{ cluster.kube_api_server }}"
+{% if 'kube_api_server' in cluster and cluster.kube_api_server %}
+  kubeAPIServer:
+{{ cluster.kube_api_server | to_nice_yaml(indent=2) | indent(width=4, indentfirst=True) }}
 {% endif %}
   etcdClusters:
     - etcdMembers:


### PR DESCRIPTION
# Fix generation of kubeAPIServer block in cluster.yml

`kube_api_server` definition can now be a dictionary with indefinite length and mixed content without Jinja2 making it a JSON string in the generated template.


## Behaviour before this PR:
```diff
--- before: build/my-cluster.k8s.local/cluster.yml
+++ after: /home/cytopia/.ansible/tmp/ansible-local-721576akp2/tmp1_KEFE/cluster.yml.j2
@@ -15,6 +15,7 @@
   docker:
     insecureRegistry: 100.64.0.0/10
     logDriver: ""
+  kubeAPIServer: "{u'oidcClientID': u'gangway', u'oidcUsernamePrefix': u'oidc:', u'oidcUsernameClaim': u'email', u'oidcIssuerURL': u'https://dex.example.org', u'oidcGroupsPrefix': u'oidc:', u'oidcGroupsClaim': u'groups'}"
   etcdClusters:
```

## Behaviour with this PR:
```diff
--- before: build/my-cluster.k8s.local/cluster.yml
+++ after: /home/cytopia/.ansible/tmp/ansible-local-4299YQF6lf/tmpWpyKWL/cluster.yml.j2
@@ -15,6 +15,19 @@
   docker:
     insecureRegistry: 100.64.0.0/10
     logDriver: ""
+  kubeAPIServer:
+    oidcClientID: gangway
+    oidcGroupsClaim: groups
+    oidcGroupsPrefix: 'oidc:'
+    oidcIssuerURL: https://dex.example.org
+    oidcUsernameClaim: email
+    oidcUsernamePrefix: 'oidc:'
+    test:
+      test1: null
+      test2:
+      - item1
+      - item2
+
   etcdClusters:
     - etcdMembers:
       - instanceGroup: master-eu-central-1a
```

## Upcoming git tag: `v1.4.1`