### PR TITLE
OPS-2677 adds support for assigning labels to worker nodes to enhance placement constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ kops_cluster:
         max_size: 3
         volume_size: 200
         availability_zones: [c]
+        node_labels:
+          - key: name
+            val: some-fancy-name
+          - key: purpose
+            value: something-important
 ```
 
 

--- a/templates/instance-groups.yml.j2
+++ b/templates/instance-groups.yml.j2
@@ -54,6 +54,11 @@ spec:
   minSize: {{ min_size }}
   nodeLabels:
     kops.k8s.io/instancegroup: {{ worker_ig }}
+{% if worker.node_labels is defined %}
+{% for label in worker.node_labels %}
+    {{ label.key }}: {{ label.val }}
+{% endfor %}
+{% endif %}
   role: Node
   rootVolumeSize: {{ root_volume_size }}
   subnets:


### PR DESCRIPTION
# Adds support for assigning labels to worker nodes to enhance placement constraints

We need to enhance existing placement constraints. By using worker node labels, we can achieve a more targeted placement.

## Upcoming git tag: `v1.4.4`

We'll need to update the definitions of our other services to ensure that once a node is exclusively allocated to a service, nothing else runs on that node.