### PR TITLE
OPS-0 Python3 compatibility

### DIFF
--- a/library/udiff.py
+++ b/library/udiff.py
@@ -170,7 +170,7 @@ def pop_recursive(dictionary, keys):
     # make sure the_keys is a set to get O(1) lookups
     #if type(keys) is not set:
     #    keys = set(keys)
-    for key, val in dictionary.items():
+    for key, val in dictionary.copy().items():
         if key in keys:
             del dictionary[key]
         if isinstance(val, dict):

--- a/library/udiff.py
+++ b/library/udiff.py
@@ -150,20 +150,13 @@ def shell_exec(command):
     cpt = subprocess.Popen(command, shell=True,
                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
-    output = []
-    for line in iter(cpt.stdout.readline, ''):
-        output.append(line)
-
-    # Wait until process terminates (without using p.wait())
-    while cpt.poll() is None:
-        # Process hasn't exited yet, let's wait some
-        time.sleep(0.5)
+    stdout, stderr = cpt.communicate()
 
     # Get return code from process
     return_code = cpt.returncode
 
     # Return code and output
-    return return_code, ''.join(output)
+    return return_code, to_bytes(stdout).decode("utf-8")
 
 
 def pop_recursive(dictionary, keys):


### PR DESCRIPTION
# Python3 compatibility

Fixes the following issues for Python3

* [x] Fix deadlock with large output (see also here: https://github.com/cytopia/metrics-server-prom/pull/11)
* [x] Fix dictionary changed size during iteration

## Next git tag: `v1.5.2`