### PR TITLE
OPS-3316 Add taints feature for worker nodes

### DIFF
--- a/templates/instance-groups.yml.j2
+++ b/templates/instance-groups.yml.j2
@@ -61,6 +61,12 @@ spec:
 {% endif %}
   role: Node
   rootVolumeSize: {{ root_volume_size }}
+{% if worker.taints is defined %}
+  taints:
+{% for taint in worker.taints %}
+    - {{ taint }}
+{% endfor %}
+{% endif %}
   subnets:
 {% for az in worker_az %}
     - {{ cluster.region | default(kops_default_region) }}{{ az }}


### PR DESCRIPTION
# Add taints feature for worker nodes

This PR adds a new feature to allow taints for worker nodes.

## Tagging

Next tag will be `v1.7.0`