### PR TITLE
Allow the usage of cloudlabels (AWS tags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ kops_cluster:
         max_size: 3
         volume_size: 200
         availability_zones: [c]
+        cloud_labels:
+          - key: team
+            val: me
+          - key: project
+            value: ion
         node_labels:
           - key: name
             val: some-fancy-name

--- a/templates/instance-groups.yml.j2
+++ b/templates/instance-groups.yml.j2
@@ -52,6 +52,12 @@ spec:
   machineType: {{ machine_type }}
   maxSize: {{ max_size }}
   minSize: {{ min_size }}
+{% if worker.cloud_labels is defined %}
+  cloudLabels:
+{% for label in worker.cloud_labels %}
+    {{ label.key }}: {{ label.val }}
+{% endfor %}
+{% endif %}
   nodeLabels:
     kops.k8s.io/instancegroup: {{ worker_ig }}
 {% if worker.node_labels is defined %}


### PR DESCRIPTION
# Allow the usage of cloudlabels (AWS tags)

This PR adds the feature to have cloudlabels (AWS tags) defined on worker nodes.

See here for details: https://github.com/kubernetes/kops/blob/master/docs/labels.md

Usage intended for AWS cost grouping of resources.


### Tagging

As this is a new feature, the new tag will be a minor version raise to: `v1.8.0`