### PR TITLE
Limit cluster roll outs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ When using this role it will simply generate the kops configuration files as wel
 to deploy each defined cluster. You can also choose to use Ansible to provision kops. This can be done for
 multiple different stages as defined below:
 
-| Variable      | Default   | Choices                 |
-|---------------|-----------|-------------------------|
-| `kops_update` | undefined | `state` `update`, `all` |
+| Variable            | Default   | Choices                 |
+|---------------------|-----------|-------------------------|
+| `kops_update`       | undefined | `state` `update`, `all` |
+| `kops_cluster_name` | undefined | If `kops_cluster` list contains more than one cluster definition, you can limit the roll-out to this specific cluster from the list. (Defined by `kops_cluster[].name`) |
 
 **Note:** As this role is fully dry-run capable you should use it in the following order for
 productionized stacks:
@@ -58,6 +59,14 @@ In order to both apply state store updates in S3 and then update the cluster acc
 to add the following variable to your Ansible command:
 ```
 -e kops_update=all
+```
+
+#### Limit update to a specific cluster
+
+In case your kops_cluster list contains multiple items, you can limit the whole roll-out/dry-run
+to a specific cluster defined by its name:
+```
+-e kops_cluster_name=playground-cluster-shop.k8s.local
 ```
 
 

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -3,14 +3,14 @@
 ###
 ### Validate required defines
 ###
-- name: ensure cluster name is defined
+- name: "({{ cluster.name }}) ensure cluster name is defined"
   assert:
     that:
       - cluster.name is defined
       - cluster.name | length > 0
     msg: "Cluster 'name' is not defined, but required"
 
-- name: ensure cluster ssh key is defined
+- name: "({{ cluster.name }}) ensure cluster ssh key is defined"
   assert:
     that:
       - >-
@@ -18,21 +18,21 @@
         (kops_default_ssh_pub_key is defined and kops_default_ssh_pub_key | length > 0)
     msg: "Cluster 'ssh_pub_key' or kops_default_ssh_pub_key is not defined, but one of them is required"
 
-- name: ensure cluster s3 bucket name is defined
+- name: "({{ cluster.name }}) ensure cluster s3 bucket name is defined"
   assert:
     that:
       - cluster.s3_bucket_name is defined
       - cluster.s3_bucket_name | length > 0
     msg: "Cluster 's3_bucket_name' is not defined, but required"
 
-- name: ensure workers array is defined
+- name: "({{ cluster.name }}) ensure workers array is defined"
   assert:
     that:
       - cluster.workers is defined
       - cluster.workers | length > 0
     msg: "No worker nodes are defined. Your cluster will be useless"
 
-- name: ensure workers array is defined correctly
+- name: "({{ cluster.name }}) ensure workers array is defined correctly"
   assert:
     that:
       - item.name is defined
@@ -44,7 +44,7 @@
 ###
 ### Validate availability zones
 ###
-- name: ensure master availability zones are within defined availability zones
+- name: "({{ cluster.name }}) ensure master availability zones are within defined availability zones"
   assert:
     that:
       - item in cluster.az | default(kops_default_az)
@@ -59,7 +59,7 @@
       {{ kops_default_master_az }}
       {%- endif -%}
 
-- name: ensure bastion availability zones are within defined availability zones
+- name: "({{ cluster.name }}) ensure bastion availability zones are within defined availability zones"
   assert:
     that:
       - item in cluster.az | default(kops_default_az)
@@ -74,7 +74,7 @@
       {{ kops_default_bastion_az }}
       {%- endif -%}
 
-- name: ensure worker availability zones are within defined availability zones
+- name: "({{ cluster.name }}) ensure worker availability zones are within defined availability zones"
   assert:
     that:
       - >-

--- a/tasks/gather_facts_subnets_private.yml
+++ b/tasks/gather_facts_subnets_private.yml
@@ -4,7 +4,7 @@
 ### Gather subnet
 ###
 
-- name: set private subnet filter
+- name: "({{ cluster.name }}) set private subnet filter"
   set_fact:
     kops_subnet_private_filters:
       - key: state
@@ -22,7 +22,7 @@
       - key: "tag:kubernetes.io/role/internal-elb"
         val: "1"
 
-- name: gather private subnet facts
+- name: "({{ cluster.name }}) gather private subnet facts"
   ec2_vpc_subnet_facts:
     aws_access_key: "{{ lookup('ENV', 'AWS_ACCESS_KEY') | default(omit) }}"
     aws_secret_key: "{{ lookup('ENV', 'AWS_SECRET_KEY') | default(omit)  }}"
@@ -32,7 +32,7 @@
     filters: "{{ kops_subnet_private_filters | get_attr('key', 'val') }}"
   register: _kops_subnet_private_facts
 
-- name: fail if not exactly one private subnet was not found
+- name: "({{ cluster.name }}) fail if not exactly one private subnet was not found"
   assert:
     that:
       - _kops_subnet_private_facts.subnets is defined
@@ -44,7 +44,7 @@
 ### Set return variable
 ###
 
-- name: set private dict item
+- name: "({{ cluster.name }}) set private dict item"
   set_fact:
     kops_private_item: |
       {{
@@ -57,6 +57,6 @@
         }
       }}
 
-- name: merge private subnet array
+- name: "({{ cluster.name }}) merge private subnet array"
   set_fact:
     kops_private_subnets: "{{ kops_private_subnets | combine(kops_private_item) }}"

--- a/tasks/gather_facts_subnets_utility.yml
+++ b/tasks/gather_facts_subnets_utility.yml
@@ -4,7 +4,7 @@
 ### Gather subnet
 ###
 
-- name: set utility subnet filter
+- name: "({{ cluster.name }}) set utility subnet filter"
   set_fact:
     kops_subnet_utility_filters:
       - key: state
@@ -22,7 +22,7 @@
       - key: "tag:kubernetes.io/role/elb"
         val: "1"
 
-- name: gather utility subnet facts
+- name: "({{ cluster.name }}) gather utility subnet facts"
   ec2_vpc_subnet_facts:
     aws_access_key: "{{ lookup('ENV', 'AWS_ACCESS_KEY') | default(omit) }}"
     aws_secret_key: "{{ lookup('ENV', 'AWS_SECRET_KEY') | default(omit)  }}"
@@ -32,7 +32,7 @@
     filters: "{{ kops_subnet_utility_filters | get_attr('key', 'val') }}"
   register: _kops_subnet_utility_facts
 
-- name: fail if not exactly one utility subnet was not found
+- name: "({{ cluster.name }}) fail if not exactly one utility subnet was not found"
   assert:
     that:
       - _kops_subnet_utility_facts.subnets is defined
@@ -44,7 +44,7 @@
 ### Gather NAT GW
 ###
 
-- name: set NAT GW filter
+- name: "({{ cluster.name }}) set NAT GW filter"
   set_fact:
     kops_subnet_utility_nat_filters:
       - key: state
@@ -54,7 +54,7 @@
       - key: subnet-id
         val: "{{ _kops_subnet_utility_facts.subnets[0].id }}"
 
-- name: gather nat gateway by filter
+- name: "({{ cluster.name }}) gather nat gateway by filter"
   ec2_vpc_nat_gateway_facts:
     aws_access_key: "{{ lookup('ENV', 'AWS_ACCESS_KEY') | default(omit) }}"
     aws_secret_key: "{{ lookup('ENV', 'AWS_SECRET_KEY') | default(omit)  }}"
@@ -64,7 +64,7 @@
     filters: "{{ kops_subnet_utility_nat_filters | get_attr('key', 'val') }}"
   register: _kops_nat_gw_facts
 
-- name: fail if not exactly one NAT gateway was found by filter
+- name: "({{ cluster.name }}) fail if not exactly one NAT gateway was found by filter"
   assert:
     that:
       - _kops_nat_gw_facts.result is defined
@@ -76,7 +76,7 @@
 ### Set return variable
 ###
 
-- name: set utility dict item
+- name: "({{ cluster.name }}) set utility dict item"
   set_fact:
     kops_utility_item: |
       {{
@@ -90,6 +90,6 @@
         }
       }}
 
-- name: merge utility subnet array
+- name: "({{ cluster.name }}) merge utility subnet array"
   set_fact:
     kops_utility_subnets: "{{ kops_utility_subnets | combine(kops_utility_item) }}"

--- a/tasks/gather_facts_vpc.yml
+++ b/tasks/gather_facts_vpc.yml
@@ -1,6 +1,7 @@
 ---
 
-- set_fact:
+- name: "({{ cluster.name }}) set VPC filter"
+  set_fact:
     kops_vpc_filters:
       - key: state
         val: available
@@ -9,7 +10,7 @@
       - key: "tag:kubernetes.io/cluster/{{ cluster.name }}"
         val: shared
 
-- name: gather vpc facts
+- name: "({{ cluster.name }}) gather vpc facts"
   ec2_vpc_net_facts:
     aws_access_key: "{{ lookup('ENV', 'AWS_ACCESS_KEY') | default(omit) }}"
     aws_secret_key: "{{ lookup('ENV', 'AWS_SECRET_KEY') | default(omit)  }}"
@@ -19,17 +20,17 @@
     filters: "{{ kops_vpc_filters | get_attr('key', 'val') }}"
   register: _kops_vpc_facts
 
-- name: fail if vpc was not found
+- name: "({{ cluster.name }}) fail if vpc was not found"
   assert:
     that:
       - _kops_vpc_facts.vpcs is defined
       - _kops_vpc_facts.vpcs | length == 1
     msg: Not exactly one VPC has been found
 
-- name: set vpc id
+- name: "({{ cluster.name }}) set vpc id"
   set_fact:
     kops_vpc_id: "{{ _kops_vpc_facts.vpcs[0].id }}"
 
-- name: set vpc cidr
+- name: "({{ cluster.name }}) set vpc cidr"
   set_fact:
     kops_vpc_cidr: "{{ _kops_vpc_facts.vpcs[0].cidr_block }}"

--- a/tasks/generate_templates.yml
+++ b/tasks/generate_templates.yml
@@ -1,11 +1,11 @@
 ---
 
-- name: ensure project build directory is present
+- name: "({{ cluster.name }}) ensure project build directory is present"
   file:
     state: directory
     path: "{{ kops_default_build_directory}}/{{ cluster.name }}"
 
-- name: generate kubernetes templates and ssh key
+- name: "({{ cluster.name }}) generate kubernetes templates and ssh key"
   template:
     src: "{{ item }}.j2"
     dest: "{{ kops_default_build_directory}}/{{ cluster.name }}/{{ item }}"
@@ -15,7 +15,7 @@
     - instance-groups.yml
     - ssh-key.pub
 
-- name: generate shell scripts
+- name: "({{ cluster.name }}) generate shell scripts"
   template:
     src: "{{ item }}.j2"
     dest: "{{ kops_default_build_directory }}/{{ cluster.name }}/{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,3 +8,5 @@
     loop_var: cluster
   with_items:
     - "{{ kops_cluster }}"
+  when:
+    - kops_cluster_name is not defined or (kops_cluster_name is defined and kops_cluster_name == cluster.name)

--- a/tasks/run_kops.yml
+++ b/tasks/run_kops.yml
@@ -3,7 +3,7 @@
 ###
 ### Diff State Store
 ###
-- name: diff generated cluster config against remote state store
+- name: "({{ cluster.name }}) diff generated cluster config against remote state store"
   udiff:
     source: "{{ lookup('template', 'cluster.yml.j2') }}"
     target: |
@@ -27,7 +27,7 @@
     - kops_update is defined
     - kops_update == 'state' or kops_update == 'update' or kops_update == 'all'
 
-- name: diff generated instance group config against remote state store
+- name: "({{ cluster.name }}) diff generated instance group config against remote state store"
   udiff:
     source: "{{ lookup('template', 'instance-groups.yml.j2') }}"
     target: |
@@ -51,7 +51,7 @@
     - kops_update is defined
     - kops_update == 'state' or kops_update == 'update' or kops_update == 'all'
 
-- name: diff ssh public key against remote state store
+- name: "({{ cluster.name }}) diff ssh public key against remote state store"
   udiff:
     source: |
       # Test SSH key for validity
@@ -85,7 +85,7 @@
 ###
 ### Update State Store
 ###
-- name: update state store for cluster spec
+- name: "({{ cluster.name }}) update state store for cluster spec"
   shell: |
     # If using boto_profile, make kops aware of it
     if [ -n "${BOTO_PROFILE}" ]; then
@@ -104,7 +104,7 @@
     - kops_update is defined
     - kops_update == 'state' or kops_update == 'update' or kops_update == 'all'
 
-- name: update state store for instance groups
+- name: "({{ cluster.name }}) update state store for instance groups"
   shell: |
     # If using boto_profile, make kops aware of it
     if [ -n "${BOTO_PROFILE}" ]; then
@@ -123,7 +123,7 @@
     - kops_update is defined
     - kops_update == 'state' or kops_update == 'update' or kops_update == 'all'
 
-- name: update state store for ssh public key
+- name: "({{ cluster.name }}) update state store for ssh public key"
   shell: |
     # If using boto_profile, make kops aware of it
     if [ -n "${BOTO_PROFILE}" ]; then
@@ -152,7 +152,7 @@
 ###
 ### Update Cluster
 ###
-- name: diff kubernetes updates
+- name: "({{ cluster.name }}) diff kubernetes updates"
   shell: |
     # If using boto_profile, make kops aware of it
     if [ -n "${BOTO_PROFILE}" ]; then
@@ -175,7 +175,7 @@
     - kops_update is defined
     - kops_update == 'update' or kops_update == 'all'
 
-- name: show diffed kubernetes updates
+- name: "({{ cluster.name }}) show diffed kubernetes updates"
   debug:
     msg: "{{ (_kops_diff_cluster_update.stdout_lines | join('\\n') | regex_replace('\\t', '')).split('\\n') }}"
   check_mode: False
@@ -185,7 +185,7 @@
     - kops_update == 'update' or kops_update == 'all'
     - _kops_diff_cluster_update.stdout_lines is defined
 
-- name: update kubernetes cluster
+- name: "({{ cluster.name }}) update kubernetes cluster"
   shell: |
     # If using boto_profile, make kops aware of it
     if [ -n "${BOTO_PROFILE}" ]; then


### PR DESCRIPTION
# Limit cluster roll outs

This PR adds the feature to limit the roll-out/dry-run to a single specific cluster from the list (if multiple have been defined) by using the `kops_cluster_name` Ansible variable:

```
-e kops_cluster_name=playground-cluster-shop.k8s.local
```

Additionally every Ansible task is now prefixed with the cluster name it is currently working on in order to provide better user information for this role.

### Tagging 

As this is a new feature, the minor version will be bumped and the final tag will be: `v1.9.0`
