### PR TITLE
Fix showing available cluster updates

### DIFF
--- a/tasks/run_kops.yml
+++ b/tasks/run_kops.yml
@@ -164,7 +164,9 @@
       --name {{ cluster.name }} )"; then \
       exit 1;
     else
-      echo "${stdout}" | grep -E '^[[:space:]]+[+-][[:space:]]' || true
+      echo "${stdout}" \
+        | grep -Ev '^No changes need to be applied' \
+        || true
     fi
   check_mode: False
   register: _kops_diff_cluster_update


### PR DESCRIPTION
### Description

This PR fixes the detection of available kops updates. This is necessary for two things:

1. Be able to show what will be changed
2. `kops update` needs changes, otherwise it will not run, so ensure we show changes if they are present

### Tagging

Next git tag will be `v1.9.1`