### PR TITLE
OPS-0 Use proper boolean values

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -8,3 +8,4 @@ ignore: |
 rules:
   line-length:
     max: 120
+  truthy: disable


### PR DESCRIPTION
This fixes:

```
$ make lint
yamllint .
./tasks/run_kops.yml
  22:15     warning  truthy value should be one of [false, true]  (truthy)
  46:15     warning  truthy value should be one of [false, true]  (truthy)
  76:15     warning  truthy value should be one of [false, true]  (truthy)
  171:15    warning  truthy value should be one of [false, true]  (truthy)
  183:15    warning  truthy value should be one of [false, true]  (truthy)
```