### PR TITLE
New feature: fileAssets

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ kops_cluster:
       oidcUsernamePrefix: "oidc:"
       oidcGroupsClaim: groups
       oidcGroupsPrefix: "oidc:"
+    # https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#fileassets
+    file_assets:
+      - name: audit-policy-config
+        path: /srv/kubernetes/audit/policy-config.yaml
+        roles:
+          - Master
+        content: |
+          apiVersion: audit.k8s.io/v1
+          kind: Policy
+          rules:
+            - level: Metadata
     additionalPolicies:
         node: |
           [

--- a/templates/cluster.yml.j2
+++ b/templates/cluster.yml.j2
@@ -30,6 +30,10 @@ spec:
   kubeAPIServer:
 {{ cluster.kube_api_server | to_nice_yaml(indent=2) | indent(width=4, indentfirst=True) }}
 {% endif %}
+{% if 'file_assets' in cluster and cluster.file_assets %}
+  fileAssets:
+{{ cluster.file_assets | to_nice_yaml(indent=2) | indent(width=4, indentfirst=True) }}
+{% endif %}
 {% if 'additionalPolicies' in cluster and cluster.additionalPolicies and
   ( 'node' in cluster.additionalPolicies and cluster.additionalPolicies.node or
   'master' in cluster.additionalPolicies and cluster.additionalPolicies.master ) %}


### PR DESCRIPTION
# New feature: fileAssets

## Description

The `fileAssets` directive is required for K8s audit logging as shown in the Kops documentation: https://kops.sigs.k8s.io/cluster_spec/#audit-logging

The fileAssets definition is as follows: https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#fileassets

## Tagging

Next tag will be `v1.9.2`

## Note

I have tested this together with audit logs and it works fine.

## Ansible definition
```yaml
cluster_internet_kops:
  ...
  file_assets:
    - name: audit-policy-config
      path: /srv/kubernetes/audit/policy-config.yaml
      roles:
        - Master
      content: |
        apiVersion: audit.k8s.io/v1
        kind: Policy
        rules:
          - level: Metadata
```

## Kops rendered
```yaml
apiVersion: kops.k8s.io/v1alpha2
kind: Cluster
metadata:
  creationTimestamp: null
  name: myclustername.k8s.local
spec:
  fileAssets:
    - content: "apiVersion: audit.k8s.io/v1\nkind: Policy\nrules:\n  - level: Metadata\n"
      name: audit-policy-config
      path: /srv/kubernetes/audit/policy-config.yaml
      roles:
      - Master
```