### PR TITLE
Allows connections to the bastion host from already-defined CIDRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Additional variables that can be used (either as `host_vars`/`group_vars` or via
 | `kops_default_region`                        | `eu-central-1` | Default region to use |
 | `kops_default_image`                         | `kope.io/k8s-1.9-debian-jessie-amd64-hvm-ebs-2018-03-11` | Default AMI to use. [See here for other AMIs'](https://github.com/kubernetes/kops/blob/master/channels/stable) |
 | `kops_default_api_access`                    | `[0.0.0.0/32]` | Array of allowed IP's to access the API from |
+| `kops_ssh_additional_cidrs_from_sg`          | `""` | Name of the Security Group with the corresponding Ingress CIDRs that will connect to the jumpbox via SSH |
 | `kops_default_ssh_access`                    | `[0.0.0.0/32]` | Array of allowed IP's to ssh into the machines from |
 | `kops_externally_managed_egress`             | `false`        | If you manage default routing separately, e.g. in case of VGW or TGW please set to True |
 | `kops_default_az`                            | `[a, b, c]`    | Available availability zones to be used by master, worker and bastion hosts |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,8 @@ kops_default_api_access:
 kops_default_ssh_access:
   - 0.0.0.0/32
 
+kops_ssh_additional_cidrs_from_sg: ""
+
 kops_default_aws_account_limit: []
 
 

--- a/tasks/create_cluster.yml
+++ b/tasks/create_cluster.yml
@@ -13,6 +13,7 @@
     kops_utility_subnets: []
     kops_private_subnets: []
     kops_api_additional_sgs: []
+    kops_ssh_additional_cidrs: []
 
 
 ###
@@ -42,6 +43,7 @@
 
 # Returns:
 # * kops_api_additional_sgs
+# * kops_ssh_additional_cidrs
 - include_tasks: gather_facts_ec2_security_groups.yml
 
 ###

--- a/tasks/gather_facts_ec2_security_groups.yml
+++ b/tasks/gather_facts_ec2_security_groups.yml
@@ -20,6 +20,26 @@
     region: "{{ cluster.region | default(kops_default_region) }}"
   register: _kops_api_additional_sgs
 
+- name: Gather facts for specified Security Group
+  ec2_group_facts:
+    aws_access_key: "{{ lookup('ENV', 'AWS_ACCESS_KEY') | default(omit) }}"
+    aws_secret_key: "{{ lookup('ENV', 'AWS_SECRET_KEY') | default(omit)  }}"
+    security_token: "{{ lookup('ENV', 'AWS_SECURITY_TOKEN') | default(omit) }}"
+    profile: "{{ kops_aws_profile | default(omit) }}"
+    region: "{{ cluster.region | default(kops_default_region) }}"
+    filters:
+      group-name:
+        - "{{ kops_ssh_additional_cidrs_from_sg }}"
+  register: _kops_ssh_additional_cidrs_facts
+
+- name: CIDRs of the additional SSH ingress access rules should be set as fact
+  set_fact:
+    kops_ssh_additional_cidrs: "{{
+      kops_ssh_additional_cidrs | default([]) + [item.cidr_ip]
+    }}"
+  with_items: "{{ _kops_ssh_additional_cidrs_facts.security_groups[0].ip_permissions[0].ip_ranges }}"
+  when: _kops_ssh_additional_cidrs_facts.security_groups | length > 0
+
 - name: Set Security Groups ID fact
   set_fact:
     kops_api_additional_sgs: "{{ kops_api_additional_sgs |

--- a/templates/cluster.yml.j2
+++ b/templates/cluster.yml.j2
@@ -95,6 +95,9 @@ spec:
 {% for ip in cluster.ssh_access | default(kops_default_ssh_access) %}
     - {{ ip }}
 {% endfor %}
+{% for ip in kops_ssh_additional_cidrs %}
+    - {{ ip }}
+{% endfor %}
   subnets:
 {% for subnet in (kops_private_subnets.keys() | sort) %}
     - cidr: {{ kops_private_subnets[subnet].cidr }}


### PR DESCRIPTION
Gets the name of a security group.
As a result, it parses the ingress rules of that SG and then returns the respective CIDRs.
Those CIDRs will be allowed to connect to the bastion host (via the ELB).