### PR TITLE
Add security settings base on master warn check in kube-bench cis-1.6

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,8 +103,14 @@ kops_default_kubelet:
   anonymousAuth: false
   authenticationTokenWebhook: true
   authorizationMode: Webhook
+  tlsCipherSuites:
+    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 kops_default_kubeControllerManager:
   enableProfiling: false
   terminatedPodGCThreshold: 12500
+  tlsCipherSuites:
+    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 kops_default_kubeScheduler:
   enableProfiling: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -105,5 +105,6 @@ kops_default_kubelet:
   authorizationMode: Webhook
 kops_default_kubeControllerManager:
   enableProfiling: false
+  terminatedPodGCThreshold: 12500
 kops_default_kubeScheduler:
   enableProfiling: false

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -193,6 +193,21 @@
       {{ kops_default_kubeControllerManager }}
       {%- endif -%}
 
+- name: "({{ cluster.name }}) ensure kube_controller_manager.terminatedPodGCThreshold is larger or equal to 0"
+  assert:
+    that:
+      - item.terminatedPodGCThreshold is defined
+      - item.terminatedPodGCThreshold >= 0
+    msg: "kube_controller_manager.terminatedPodGCThreshold should >= 0"
+  with_items:
+    - >-
+      {%- if cluster.kube_controller_manager is defined and
+            'terminatedPodGCThreshold' in cluster.kube_controller_manager -%}
+      {{ cluster.kube_controller_manager }}
+      {%- else -%}
+      {{ kops_default_kubeControllerManager }}
+      {%- endif -%}
+
 - name: "({{ cluster.name }}) ensure kubeScheduler.enableProfiling is boolean"
   assert:
     that:

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -179,6 +179,20 @@
       {{ kops_default_kubelet }}
       {%- endif -%}
 
+- name: "({{ cluster.name }}) ensure kops_kubelet.tlsCipherSuites is list(string)"
+  assert:
+    that:
+      - item.tlsCipherSuites is defined
+      - item.tlsCipherSuites | type_debug == "list"
+    msg: "kops_kubelet.tlsCipherSuites should be list(string)"
+  with_items:
+    - >-
+      {%- if cluster.kops_kubelet is defined and 'tlsCipherSuites' in cluster.kops_kubelet -%}
+      {{ cluster.kops_kubelet }}
+      {%- else -%}
+      {{ kops_default_kubelet }}
+      {%- endif -%}
+
 - name: "({{ cluster.name }}) ensure kubeControllerManager.enableProfiling is boolean"
   assert:
     that:
@@ -203,6 +217,20 @@
     - >-
       {%- if cluster.kube_controller_manager is defined and
             'terminatedPodGCThreshold' in cluster.kube_controller_manager -%}
+      {{ cluster.kube_controller_manager }}
+      {%- else -%}
+      {{ kops_default_kubeControllerManager }}
+      {%- endif -%}
+
+- name: "({{ cluster.name }}) ensure kube_controller_manager.tlsCipherSuites is list(string)"
+  assert:
+    that:
+      - item.tlsCipherSuites is defined
+      - item.tlsCipherSuites | type_debug == "list"
+    msg: "kube_controller_manager.tlsCipherSuites should be list(string)"
+  with_items:
+    - >-
+      {%- if cluster.kube_controller_manager is defined and 'tlsCipherSuites' in cluster.kube_controller_manager -%}
       {{ cluster.kube_controller_manager }}
       {%- else -%}
       {{ kops_default_kubeControllerManager }}

--- a/templates/cluster.yml.j2
+++ b/templates/cluster.yml.j2
@@ -8,10 +8,18 @@ spec:
     anonymousAuth: {{ cluster.kops_kubelet.anonymousAuth | default(kops_default_kubelet.anonymousAuth) }}
     authenticationTokenWebhook: {{ cluster.kops_kubelet.authenticationTokenWebhook | default(kops_default_kubelet.authenticationTokenWebhook) }}
     authorizationMode: {{ cluster.kops_kubelet.authorizationMode | default(kops_default_kubelet.authorizationMode) }}
+{% if 'kops_kubelet' in cluster and 'tlsCipherSuites' in cluster.kops_kubelet %}
+    tlsCipherSuites:
+{{ cluster.kops_kubelet.tlsCipherSuites | to_nice_yaml(indent=2) | indent(width=6, first=True) -}}
+{% endif %}
   kubeControllerManager:
     enableProfiling: {{ cluster.kops_kubeControllerManager.enableProfiling | default(kops_default_kubeControllerManager.enableProfiling) }}
 {% if cluster.kube_controller_manager.terminatedPodGCThreshold is defined %}
     terminatedPodGCThreshold: {{ cluster.kube_controller_manager.terminatedPodGCThreshold }}
+{% endif %}
+{% if 'kube_controller_manager' in cluster and 'tlsCipherSuites' in cluster.kube_controller_manager %}
+    tlsCipherSuites:
+{{ cluster.kube_controller_manager.tlsCipherSuites | to_nice_yaml(indent=2) | indent(width=6, first=True) -}}
 {% endif %}
   kubeScheduler:
     enableProfiling: {{ cluster.kops_kubeScheduler.enableProfiling | default(kops_default_kubeScheduler.enableProfiling) }}

--- a/templates/cluster.yml.j2
+++ b/templates/cluster.yml.j2
@@ -10,6 +10,9 @@ spec:
     authorizationMode: {{ cluster.kops_kubelet.authorizationMode | default(kops_default_kubelet.authorizationMode) }}
   kubeControllerManager:
     enableProfiling: {{ cluster.kops_kubeControllerManager.enableProfiling | default(kops_default_kubeControllerManager.enableProfiling) }}
+{% if cluster.kube_controller_manager.terminatedPodGCThreshold is defined %}
+    terminatedPodGCThreshold: {{ cluster.kube_controller_manager.terminatedPodGCThreshold }}
+{% endif %}
   kubeScheduler:
     enableProfiling: {{ cluster.kops_kubeScheduler.enableProfiling | default(kops_default_kubeScheduler.enableProfiling) }}
   api:


### PR DESCRIPTION
- [terminated-pod-gc-threshold in Controller Manage](https://github.com/aquasecurity/kube-bench/blob/2d6bf55ab2ae3e0b919312a6c5cf3ddada7eb214/cfg/cis-1.6/master.yaml#L866)
  add the parameter to control terminated-pod-gc-threshold
- [tls-cipher-suites in api server](https://github.com/aquasecurity/kube-bench/blob/2d6bf55ab2ae3e0b919312a6c5cf3ddada7eb214/cfg/cis-1.6/master.yaml#L845) 
- [tls-cipher-suites in kubelet](https://github.com/aquasecurity/kube-bench/blob/2d6bf55ab2ae3e0b919312a6c5cf3ddada7eb214/cfg/cis-1.6/node.yaml#L447)

### Comming release v1.18.0